### PR TITLE
Add scheduler class to fix line 60

### DIFF
--- a/src/TurfWars/Main.php
+++ b/src/TurfWars/Main.php
@@ -32,9 +32,7 @@ use pocketmine\block\Block;
 use pocketmine\entity\Arrow;
 use pocketmine\entity\Entity;
 
-
-
-
+use pocketmine\scheduler\TaskScheduler;
 
 use pocketmine\nbt\tag\IntTag;
 use pocketmine\nbt\tag\CompoundTag;


### PR DESCRIPTION
Adds `use pocketmine\scheduler\TaskScheduler;` to fix an issue on Line 60 that occurs when loading the Plugin.